### PR TITLE
feat(#293): Improve `systemd` installation

### DIFF
--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -148,6 +148,7 @@ class Service:
         self.path = (USER_INSTALL_PATH if user_mode else SYSTEM_INSTALL_PATH) / SERVICE_NAME
 
     def _install_system(self, content: str) -> str:
+        # TODO[#293]: don't use `sudo` if already running as root
         with sudo:
             logger.info('writing to %s', self.path)
             sh.mkdir('-p', str(self.path.parent))
@@ -167,6 +168,7 @@ class Service:
         return sh.systemctl.status('--user', self.path.name)
 
     def _uninstall_system(self) -> None:
+        # TODO[#293]: don't use `sudo` if already running as root
         with sudo:
             logger.info('stopping and disabling %s', self.path.name)
             sh.systemctl.disable('--now', self.path.name)

--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -68,15 +68,22 @@ USER_INSTALL_PATH = (
 __all__ = ['SYSTEM_INSTALL_PATH', 'USER_INSTALL_PATH', 'Service', 'notify']
 logger = logging.getLogger(__name__)
 
+
+@contextlib.contextmanager
+def dummy() -> typing.Iterator[None]:
+    """Define a dummy context manager to use instead of `sudo`.
+
+    There are a few scenarios where `sudo` is unavailable or unnecessary:
+    - running on Windows
+    - running in a container without `sudo` installed
+    - already running as root
+    """
+    yield
+
+
 try:
     sudo = sh.contrib.sudo
 except AttributeError:  # pragma: no cover
-
-    @contextlib.contextmanager
-    def dummy() -> typing.Iterator[None]:
-        """We might be running inside a container; or we might be on Windows."""
-        yield
-
     sudo = dummy()
 
 
@@ -133,6 +140,8 @@ class Service:
     path: Path
     """The installation location of the `systemd` unit file."""
 
+    sudo: typing.ContextManager[None]
+
     tmpl: jinja2.Template
     """Load the template on initialization."""
 
@@ -147,16 +156,19 @@ class Service:
         self.user_mode = user_mode
         self.path = (USER_INSTALL_PATH if user_mode else SYSTEM_INSTALL_PATH) / SERVICE_NAME
 
-    def _install_system(self, content: str) -> str:
-        # TODO[#293]: don't use `sudo` if already running as root
-        with sudo:
-            logger.info('writing to %s', self.path)
-            sh.mkdir('-p', str(self.path.parent))
-            sh.tee(str(self.path), _in=content, _out='/dev/null')
+        if os.geteuid() == 0:
+            self.sudo = dummy()
+        else:
+            self.sudo = sudo
 
-            logger.info('enabling and starting %s', self.path.name)
-            sh.systemctl.start(self.path.name)
-            return sh.systemctl.status(self.path.name)
+    def _install_system(self, content: str) -> str:
+        logger.info('writing to %s', self.path)
+        sh.mkdir('-p', str(self.path.parent))
+        sh.tee(str(self.path), _in=content, _out='/dev/null')
+
+        logger.info('enabling and starting %s', self.path.name)
+        sh.systemctl.start(self.path.name)
+        return sh.systemctl.status(self.path.name)
 
     def _install_user(self, content: str) -> str:
         logger.info('writing to %s', self.path)
@@ -168,13 +180,11 @@ class Service:
         return sh.systemctl.status('--user', self.path.name)
 
     def _uninstall_system(self) -> None:
-        # TODO[#293]: don't use `sudo` if already running as root
-        with sudo:
-            logger.info('stopping and disabling %s', self.path.name)
-            sh.systemctl.disable('--now', self.path.name)
+        logger.info('stopping and disabling %s', self.path.name)
+        sh.systemctl.disable('--now', self.path.name)
 
-            logger.info('removing %s', self.path)
-            sh.rm(str(self.path))
+        logger.info('removing %s', self.path)
+        sh.rm(str(self.path))
 
     def _uninstall_user(self) -> None:
         logger.info('stopping and disabling %s', self.path.name)
@@ -188,7 +198,12 @@ class Service:
         rendered = self.render(**kwargs)
         if self.user_mode:
             return self._install_user(rendered)
-        return self._install_system(rendered)
+
+        if os.geteuid() == 0:
+            return self._install_system(rendered)
+
+        with sudo:
+            return self._install_system(rendered)
 
     def read(self) -> str:
         """Read the `systemd` service file."""
@@ -206,6 +221,10 @@ class Service:
     def uninstall(self) -> None:
         """Disable, stop, and delete the service."""
         if self.user_mode:
-            self._uninstall_user()
-        else:
-            self._uninstall_system()
+            return self._uninstall_user()
+
+        if os.geteuid() == 0:
+            return self._uninstall_system()
+
+        with sudo:
+            return self._uninstall_system()

--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -78,7 +78,7 @@ def dummy() -> typing.Iterator[None]:
     - running in a container without `sudo` installed
     - already running as root
     """
-    yield
+    yield  # pragma: no cover
 
 
 try:

--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -200,11 +200,6 @@ class Service:
             kwargs['workdir'] = Path(workdir).absolute()
 
         kwargs.setdefault('user_mode', self.user_mode)
-        if hasattr(os, 'geteuid'):  # pragma: no cover  # windows
-            kwargs.setdefault('user', os.geteuid())
-
-        if hasattr(os, 'getegid'):  # pragma: no cover  # windows
-            kwargs.setdefault('group', os.getegid())
 
         return self.tmpl.render(**kwargs)
 

--- a/src/config_ninja/templates/systemd.service.j2
+++ b/src/config_ninja/templates/systemd.service.j2
@@ -15,7 +15,6 @@ Restart=always
 RestartSec=30s
 Type=notify
 {%- if not user_mode %}
-# always run as the calling user, even when installed to the system
 User={{ user }}
 Group={{ group }}
 {%- endif %}

--- a/src/config_ninja/templates/systemd.service.j2
+++ b/src/config_ninja/templates/systemd.service.j2
@@ -14,8 +14,10 @@ ExecStart={{ config_ninja_cmd }} monitor
 Restart=always
 RestartSec=30s
 Type=notify
-{%- if not user_mode %}
+{%- if user %}
 User={{ user }}
+{%- endif %}
+{%- if group %}
 Group={{ group }}
 {%- endif %}
 {%- if workdir %}

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -313,6 +313,26 @@ def _clean_output(text: str) -> str:
 
 
 @pytest.mark.usefixtures('monkeypatch_systemd')
+def test_install_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the `install` command supports the `--env` argument."""
+    # Arrange
+    variables = {
+        var: uuid.uuid4().hex
+        for var in ['AWS_PROFILE', 'AWS_DEFAULT_FORMAT', 'AWS_DEFAULT_REGION', 'ANOTHER_ENV']
+    }
+    for name, value in variables.items():
+        monkeypatch.setenv(name, value)
+
+    # Act
+    result = runner.invoke(app, ['self', 'install', '--print-only', '--env', ','.join(variables)])
+
+    # Assert
+    assert result.exit_code == 0, result.exception
+    for name, value in variables.items():
+        assert f'Environment={name}={value}' in result.stdout
+
+
+@pytest.mark.usefixtures('monkeypatch_systemd')
 def test_install_print_only() -> None:
     """Verify the `install` command respects the `--print-only` argument."""
     result = runner.invoke(app, ['self', 'install', '--print-only'])
@@ -322,7 +342,7 @@ def test_install_print_only() -> None:
 
 
 @pytest.mark.usefixtures('monkeypatch_systemd')
-def test_called_with_sudo(mocker: MockerFixture) -> None:
+def test_install_called_with_sudo(mocker: MockerFixture) -> None:
     """Emulate when the `install` command is invoked with `sudo` (or is running as `root`).
 
     The user should not be prompted for their password if the command was run as `root` or was
@@ -377,6 +397,18 @@ def test_install_variables() -> None:
 
 
 @pytest.mark.usefixtures('monkeypatch_systemd')
+def test_install_variables_invalid() -> None:
+    """Verify the `install` command fails when an invalid variable is provided."""
+    # Arrange
+    pair = 'VARIABLE:INVALID'
+    result = runner.invoke(app, ['self', 'install', '--print-only', '--var', pair])
+
+    # Assert
+    assert result.exit_code == 1
+    assert f'Invalid argument (expected VARIABLE=VALUE pair): {pair}' in result.stdout
+
+
+@pytest.mark.usefixtures('monkeypatch_systemd')
 def test_uninstall() -> None:
     """Verify the `uninstall` command works as expected."""
     # Arrange
@@ -408,3 +440,22 @@ def test_uninstall_print_only() -> None:
     assert result.exit_code == 0, result.exception
     assert _clean_output(str(systemd.SYSTEM_INSTALL_PATH)) in _clean_output(result.stdout)
     assert content in result.stdout
+
+
+@pytest.mark.usefixtures('monkeypatch_systemd')
+def test_uninstall_called_with_sudo(mocker: MockerFixture) -> None:
+    """Emulate when the `uninstall` command is invoked with `sudo` (or is running as `root`).
+
+    The user should not be prompted for their password if the command was run as `root` or was
+    called with `sudo`.
+    """
+    # Arrange
+    sudo: mock.MagicMock = systemd.sudo  # type: ignore[assignment]
+    mocker.patch('os.geteuid', return_value=0)
+
+    # Act
+    result = runner.invoke(app, ['self', 'uninstall'])
+
+    # Assert
+    assert result.exit_code == 0, result.exception
+    sudo.__enter__.assert_not_called()

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -8,6 +8,7 @@ import string
 import uuid
 from pathlib import Path
 from typing import Any, AsyncIterable, Sequence
+from unittest import mock
 
 import pyspry
 import pytest
@@ -90,10 +91,8 @@ def test_missing_settings(mocker: MockerFixture) -> None:
     # Assert
     assert result.exit_code == 0
     assert all(
-        [
-            text in result.stdout
-            for text in ['WARNING', 'Could not find', 'config-ninja', 'settings file']
-        ]
+        text in result.stdout
+        for text in ['WARNING', 'Could not find', 'config-ninja', 'settings file']
     )
 
 
@@ -248,7 +247,8 @@ def test_apply_all(settings: dict[str, Any]) -> None:
     )
 
 
-def test_apply_all_poll(settings: dict[str, Any]) -> None:
+@pytest.mark.usefixtures('settings')
+def test_apply_all_poll() -> None:
     """Ensure the `--poll` argument cannot be used without a key."""
     result = runner.invoke(app, ['--config', 'examples/local-backend.yaml', 'apply', '--poll'])
     assert result.exit_code != 0
@@ -319,6 +319,60 @@ def test_install_print_only() -> None:
 
     assert result.exit_code == 0, result.exception
     assert _clean_output(str(systemd.SYSTEM_INSTALL_PATH)) in _clean_output(result.stdout)
+
+
+@pytest.mark.usefixtures('monkeypatch_systemd')
+def test_called_with_sudo() -> None:
+    """Emulate when the `install` command is invoked with `sudo` (or is running as `root`).
+
+    The user should not be prompted for their password if the command was run as `root` or was
+    called with `sudo`.
+    """
+    # Arrange
+    sudo: mock.MagicMock = systemd.sudo  # pyright: ignore[reportAssignmentType]
+
+    # Act
+    result = runner.invoke(app, ['self', 'install'])
+
+    # Assert
+    assert result.exit_code == 0, result.exception
+    sudo.__enter__.assert_not_called()
+
+
+@pytest.mark.parametrize('run_as', ['somebody', 'a_user:a_group'])
+@pytest.mark.usefixtures('monkeypatch_systemd')
+def test_install_run_as(run_as: str) -> None:
+    """Verify the `install` command supports the `--run-as USER[:GROUP]` argument."""
+    # Arrange
+    split = run_as.split(':')
+    user = split[0]
+    group = split[1] if len(split) > 1 else None
+
+    # Act
+    result = runner.invoke(app, ['self', 'install', '--print-only', '--run-as', run_as])
+
+    # Assert
+    assert result.exit_code == 0, {result.exception: str(result.stdout)}
+    assert f'User={user}' in result.stdout
+    if group:
+        assert f'Group={group}' in result.stdout
+
+
+@pytest.mark.usefixtures('monkeypatch_systemd')
+def test_install_variables() -> None:
+    """Verify the `install` command supports the `--var NAME=VALUE` argument."""
+    # Arrange
+    variables = {'FOO': 'BAR', 'BAZ': 'QUX'}
+    args = [f'--var {k}={v}' for k, v in variables.items()]
+    expected = [f'Environment={k}={v}' for k, v in variables.items()]
+
+    # Act
+    result = runner.invoke(app, ['self', 'install', '--print-only', *args])
+
+    # Assert
+    assert result.exit_code == 0, {result.exception: str(result.stdout)}
+    for line in expected:
+        assert line in result.stdout
 
 
 @pytest.mark.usefixtures('monkeypatch_systemd')

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -322,7 +322,7 @@ def test_install_print_only() -> None:
 
 
 @pytest.mark.usefixtures('monkeypatch_systemd')
-def test_called_with_sudo() -> None:
+def test_called_with_sudo(mocker: MockerFixture) -> None:
     """Emulate when the `install` command is invoked with `sudo` (or is running as `root`).
 
     The user should not be prompted for their password if the command was run as `root` or was
@@ -330,6 +330,7 @@ def test_called_with_sudo() -> None:
     """
     # Arrange
     sudo: mock.MagicMock = systemd.sudo  # type: ignore[assignment]
+    mocker.patch('os.geteuid', return_value=0)
 
     # Act
     result = runner.invoke(app, ['self', 'install'])

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -329,7 +329,7 @@ def test_called_with_sudo() -> None:
     called with `sudo`.
     """
     # Arrange
-    sudo: mock.MagicMock = systemd.sudo  # pyright: ignore[reportAssignmentType]
+    sudo: mock.MagicMock = systemd.sudo  # type: ignore[assignment]
 
     # Act
     result = runner.invoke(app, ['self', 'install'])
@@ -362,9 +362,9 @@ def test_install_run_as(run_as: str) -> None:
 def test_install_variables() -> None:
     """Verify the `install` command supports the `--var NAME=VALUE` argument."""
     # Arrange
-    variables = {'FOO': 'BAR', 'BAZ': 'QUX'}
-    args = [f'--var {k}={v}' for k, v in variables.items()]
-    expected = [f'Environment={k}={v}' for k, v in variables.items()]
+    variables = [f'{k}={v}' for k, v in {'FOO': 'BAR', 'BAZ': 'QUX'}.items()]
+    args = [arg for var in variables for arg in ['--var', var]]
+    expected = [f'Environment={var}' for var in variables]
 
     # Act
     result = runner.invoke(app, ['self', 'install', '--print-only', *args])


### PR DESCRIPTION
Closes #293 

## Acceptance Tests

- #293
  - [x] A.C. 1: [tests/test_config_ninja/test_cli.py::test_install_called_with_sudo](https://github.com/config-ninja/config-ninja/pull/295/files#diff-9af4ca7175acc0cb5be3726728b4285cf45341db103d8826e99b99ad389982e8R365)
  - [x] A.C. 2: [tests/test_config_ninja/test_cli.py::test_install_run_as](https://github.com/config-ninja/config-ninja/pull/295/files#diff-9af4ca7175acc0cb5be3726728b4285cf45341db103d8826e99b99ad389982e8R345)
  - [x] A.C. 3: [tests/test_config_ninja/test_cli.py::test_install_variables](https://github.com/config-ninja/config-ninja/pull/295/files#diff-9af4ca7175acc0cb5be3726728b4285cf45341db103d8826e99b99ad389982e8R365)