### PR TITLE
feat: Support multiple keys & improve logging 

### DIFF
--- a/.github/actions/poe/action.yaml
+++ b/.github/actions/poe/action.yaml
@@ -26,6 +26,9 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+    - run: poetry env use ${{ inputs.python-version }}
+      shell: sh
+
     - id: poetry
       run: tr -d '\n' <<<"${{ inputs.poetry-groups }}" |
         tr -c '[:alnum:]' '-' |

--- a/.github/workflows/pr-poe.yaml
+++ b/.github/workflows/pr-poe.yaml
@@ -25,6 +25,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         py: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,10 @@ repos:
           - typing_extensions
           - watchfiles
 
+        # mypy sometimes encounters false positives when run on individual files (instead of the whole project)
+        args: ["."]
+        pass_filenames: false
+
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.381
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,6 +73,8 @@ repos:
           - boto3-stubs[appconfig,appconfigdata]
           - jinja2
           - pyspry
+          - pytest
+          - pytest-mock
           - pyyaml
           - sdnotify
           - sh

--- a/ptw.ini
+++ b/ptw.ini
@@ -7,5 +7,7 @@ addopts =
     --cov-report=html:./docs/reports/pytest-html
     --cov-report=xml:./docs/reports/coverage.xml
     --doctest-modules
+    --durations=10
+    --ignore=docs
     --junitxml=docs/reports/pytest.xml
     .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -672,17 +672,18 @@ confidence = [
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
 disable = [
-  "raw-checker-failed",
   "bad-inline-option",
-  "locally-disabled",
-  "file-ignored",
-  "suppressed-message",
-  "useless-suppression",
   "deprecated-pragma",
-  "use-symbolic-message-instead",
+  "file-ignored",
+  "line-too-long",
+  "locally-disabled",
+  "raw-checker-failed",
+  "no-member",
+  "suppressed-message",
   "too-few-public-methods",
   "unused-import",
-  "line-too-long"
+  "use-symbolic-message-instead",
+  "useless-suppression",
 ]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -365,6 +365,8 @@ cmd = """
     --cov-report=html:./docs/reports/pytest-html
     --cov-report=xml:./docs/reports/coverage.xml
     --doctest-glob=README.md
+    --durations=10
+    --ignore=docs
     --junitxml=docs/reports/pytest.xml
     .
 """

--- a/src/config_ninja/__main__.py
+++ b/src/config_ninja/__main__.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 def main() -> None:  # pylint: disable=missing-function-docstring  # noqa: D103
-    logging.basicConfig(level=logging.INFO)
     app(prog_name='config-ninja')
 
 

--- a/src/config_ninja/backend.py
+++ b/src/config_ninja/backend.py
@@ -71,6 +71,23 @@ def loads(fmt: FormatT, raw: str) -> dict[str, Any]:
 class Backend(abc.ABC):
     """Define the API for backend implementations."""
 
+    def __repr__(self) -> str:
+        """Represent the backend object as its invocation.
+
+        >>> example = ExampleBackend('an example')
+        >>> example
+        ExampleBackend(source='an example')
+        """
+        annotations = (klass := self.__class__).__annotations__
+        annotations.pop('return', None)
+
+        args = ', '.join(f'{key}={getattr(self, key)!r}' for key in annotations if hasattr(self, key))
+        return f'{klass.__name__}({args})'
+
+    @abc.abstractmethod
+    def __str__(self) -> str:
+        """When formatted as a string, represent the backend as the identifier of its source."""
+
     @abc.abstractmethod
     def get(self) -> str:
         """Retrieve the configuration as a raw string."""

--- a/src/config_ninja/cli.py
+++ b/src/config_ninja/cli.py
@@ -25,24 +25,12 @@ from rich.markdown import Markdown
 
 import config_ninja
 from config_ninja import controller, systemd
+from config_ninja.controller import SYSTEMD_AVAILABLE
 
 try:
     from typing import Annotated, TypeAlias  # type: ignore[attr-defined,unused-ignore]
 except ImportError:  # pragma: no cover
     from typing_extensions import Annotated, TypeAlias  # type: ignore[assignment,attr-defined,unused-ignore]
-
-if typing.TYPE_CHECKING:  # pragma: no cover
-    import sh
-
-    SYSTEMD_AVAILABLE = True
-else:
-    try:
-        import sh
-    except ImportError:  # pragma: no cover
-        sh = None
-        SYSTEMD_AVAILABLE = False
-    else:
-        SYSTEMD_AVAILABLE = hasattr(sh, 'systemctl')
 
 
 # ruff: noqa: PLR0913

--- a/src/config_ninja/cli.py
+++ b/src/config_ninja/cli.py
@@ -236,7 +236,7 @@ def configure_logging(ctx: typer.Context, verbose: typing.Optional[bool] = None)
     >>> caplog.messages
     ['logging verbosity set to [green]DEBUG[/green]']
     """
-    if ctx.resilient_parsing:
+    if ctx.resilient_parsing:  # pragma: no cover  # this is for tab completions
         return
 
     verbosity = logging.DEBUG if verbose else logging.INFO
@@ -257,6 +257,7 @@ VerbosityAnnotation = Annotated[
         '-v',
         '--verbose',
         callback=configure_logging,
+        rich_help_panel='Global',
         help='Log messages at the [black]DEBUG[/] level.',
         is_eager=True,
         show_default=False,
@@ -280,6 +281,7 @@ VersionAnnotation = Annotated[
         '-V',
         '--version',
         callback=version_callback,
+        rich_help_panel='Global',
         show_default=False,
         is_eager=True,
         help='Print the version and exit.',

--- a/src/config_ninja/cli.py
+++ b/src/config_ninja/cli.py
@@ -56,6 +56,8 @@ __all__ = [
     'main',
 ]
 
+LOG_VERBOSITY_MESSAGE = 'logging verbosity set to [green]%s[/green]'
+
 logger = logging.getLogger(__name__)
 
 app_kwargs: typing.Dict[str, typing.Any] = {
@@ -210,6 +212,9 @@ VariableAnnotation: TypeAlias = Annotated[
     ),
 ]
 
+# TODO[#619]: define annotation for the `--verbose` option
+VerbosityAnnotation = Annotated[typing.Optional[bool], typer.Option('-v', '--verbose')]
+
 
 def version_callback(ctx: typer.Context, value: typing.Optional[bool] = None) -> None:
     """Print the version of the package."""
@@ -224,7 +229,7 @@ def version_callback(ctx: typer.Context, value: typing.Optional[bool] = None) ->
 VersionAnnotation = Annotated[
     typing.Optional[bool],
     typer.Option(
-        '-v',
+        '-V',
         '--version',
         callback=version_callback,
         show_default=False,

--- a/src/config_ninja/conftest.py
+++ b/src/config_ninja/conftest.py
@@ -77,6 +77,7 @@ def mock_context(mocker: pytest_mock.MockerFixture) -> MagicMock:
 def src_doctest_namespace(  # noqa: PLR0913
     doctest_namespace: dict[str, Any],
     mock_appconfigdata_client: AppConfigDataClient,
+    mock_appconfigdata_client_first_empty: AppConfigDataClient,
     example_file: Path,
     monkeypatch_systemd: tuple[Path, Path],
     mock_context: MagicMock,
@@ -96,6 +97,7 @@ def src_doctest_namespace(  # noqa: PLR0913
     doctest_namespace['example_file'] = example_file
     doctest_namespace['pytest'] = pytest
     doctest_namespace['appconfigdata_client'] = mock_appconfigdata_client
+    doctest_namespace['appconfigdata_client_first_empty'] = mock_appconfigdata_client_first_empty
     doctest_namespace['ExampleBackend'] = ExampleBackend
     doctest_namespace['ctx'] = mock_context
     doctest_namespace['caplog'] = caplog

--- a/src/config_ninja/conftest.py
+++ b/src/config_ninja/conftest.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, AsyncIterator, Iterator
 
 import pytest
 from mypy_boto3_appconfigdata import AppConfigDataClient
+
+from config_ninja.backend import Backend
 
 _no_default = object()
 
@@ -48,6 +50,28 @@ def py_anext(iterator: Iterator[Any], default: Any = _no_default) -> Any:  # pra
     return anext_impl()
 
 
+class ExampleBackend(Backend):
+    """A sample backend class used in `doctest` tests."""
+
+    source: str
+
+    def __init__(self, source: str) -> None:
+        """Initialize the backend with the given `source`."""
+        self.source = source
+
+    def __str__(self) -> str:
+        """Format a mock source identifier to satisfy `abc.abstractmethod()`."""
+        return f'sid: {self.source}'
+
+    def get(self) -> str:
+        """Dummy method to retrieve an example configuration."""
+        return 'example configuration'
+
+    async def poll(self, interval: int = 0) -> AsyncIterator[str]:
+        """Dummy method to poll the configuration."""
+        yield 'example configuration'
+
+
 @pytest.fixture(autouse=True)
 def src_doctest_namespace(
     doctest_namespace: dict[str, Any],
@@ -65,4 +89,5 @@ def src_doctest_namespace(
     doctest_namespace['example_file'] = example_file
     doctest_namespace['pytest'] = pytest
     doctest_namespace['appconfigdata_client'] = mock_appconfigdata_client
+    doctest_namespace['ExampleBackend'] = ExampleBackend
     return doctest_namespace

--- a/src/config_ninja/conftest.py
+++ b/src/config_ninja/conftest.py
@@ -16,12 +16,12 @@ from config_ninja.backend import Backend
 
 _no_default = object()
 
-# pylint: disable=too-complex,redefined-outer-name,too-many-arguments
+# pylint: disable=redefined-outer-name,too-many-arguments
 
 
 # note: the following is needed for testing on Python < 3.10
 # ref: https://docs.python.org/3/library/functions.html#anext
-def py_anext(iterator: Iterator[Any], default: Any = _no_default) -> Any:  # pragma: no cover
+def py_anext(iterator: Iterator[Any], default: Any = _no_default) -> Any:  # pylint: disable=too-complex   # pragma: no cover
     """Pure-Python implementation of anext() for testing purposes.
 
     Closely matches the builtin anext() C implementation.

--- a/src/config_ninja/conftest.py
+++ b/src/config_ninja/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
-from typing import Any, AsyncIterator, Iterator
+from typing import Any, Iterator
 
 import pytest
 from mypy_boto3_appconfigdata import AppConfigDataClient
@@ -50,26 +50,16 @@ def py_anext(iterator: Iterator[Any], default: Any = _no_default) -> Any:  # pra
     return anext_impl()
 
 
-class ExampleBackend(Backend):
+class ExampleBackend:
     """A sample backend class used in `doctest` tests."""
 
     source: str
 
+    __repr__ = Backend.__repr__
+
     def __init__(self, source: str) -> None:
         """Initialize the backend with the given `source`."""
         self.source = source
-
-    def __str__(self) -> str:
-        """Format a mock source identifier to satisfy `abc.abstractmethod()`."""
-        return f'sid: {self.source}'
-
-    def get(self) -> str:
-        """Dummy method to retrieve an example configuration."""
-        return 'example configuration'
-
-    async def poll(self, interval: int = 0) -> AsyncIterator[str]:
-        """Dummy method to poll the configuration."""
-        yield 'example configuration'
 
 
 @pytest.fixture(autouse=True)

--- a/src/config_ninja/contrib/appconfig.py
+++ b/src/config_ninja/contrib/appconfig.py
@@ -90,13 +90,14 @@ class AppConfigBackend(Backend):
     def __str__(self) -> str:
         """Include properties in the string representation.
 
-        >>> print(str(AppConfigBackend(appconfigdata_client, 'app-id', 'conf-id', 'env-id')))
-        AppConfigBackend(app_id='app-id', conf_profile_id='conf-id', env_id='env-id')
+        >>> print(str( AppConfigBackend(appconfigdata_client, 'app-id', 'conf-id', 'env-id') ))
+        boto3.client('appconfigdata').start_configuration_session(ApplicationIdentifier='app-id', ConfigurationProfileIdentifier='conf-id', EnvironmentIdentifier='env-id')
         """
         return (
-            f"{self.__class__.__name__}(app_id='{self.application_id}', "
-            f"conf_profile_id='{self.configuration_profile_id}', "
-            f"env_id='{self.environment_id}')"
+            "boto3.client('appconfigdata').start_configuration_session("
+            f"ApplicationIdentifier='{self.application_id}', "
+            f"ConfigurationProfileIdentifier='{self.configuration_profile_id}', "
+            f"EnvironmentIdentifier='{self.environment_id}')"
         )
 
     @staticmethod
@@ -145,7 +146,7 @@ class AppConfigBackend(Backend):
         return cls._get_id_from_name(name, 'list_environments', client, ApplicationId=application_id)
 
     @classmethod
-    def new(  # pyright: ignore[reportIncompatibleMethodOverride]
+    def new(  # pylint: disable=arguments-differ  # pyright: ignore[reportIncompatibleMethodOverride]
         cls,
         application_name: str,
         configuration_profile_name: str,
@@ -162,7 +163,7 @@ class AppConfigBackend(Backend):
 
         >>> backend = AppConfigBackend.new('app-name', 'conf-name', 'env-name', session)
         >>> print(f"{backend}")
-        AppConfigBackend(app_id='id-1', conf_profile_id='id-1', env_id='id-1')
+        boto3.client('appconfigdata').start_configuration_session(ApplicationIdentifier='id-1', ConfigurationProfileIdentifier='id-1', EnvironmentIdentifier='id-1')
 
         ### Error: No IDs Found
 
@@ -210,7 +211,7 @@ class AppConfigBackend(Backend):
         .. note::
             Methods written for `asyncio` need to jump through hoops to run as `doctest` tests.
             To improve the readability of this documentation, each Python code block corresponds to
-            a `doctest` test a private method.
+            a `doctest` test defined in a private method.
 
         ## Usage: `AppConfigBackend.poll()`
 

--- a/src/config_ninja/contrib/appconfig.py
+++ b/src/config_ninja/contrib/appconfig.py
@@ -166,7 +166,10 @@ class AppConfigBackend(Backend):
 
         ## Usage: `AppConfigBackend.new()`
 
-        >>> session = getfixture('mock_session_with_1_id')  # fixture for doctest
+        <!-- fixture is used for doctest but excluded from documentation
+        >>> session = getfixture('mock_session_with_1_id')
+
+        -->
 
         Use `boto3` to fetch IDs for based on name:
 
@@ -255,7 +258,7 @@ class AppConfigBackend(Backend):
             try:
                 resp = self.client.get_latest_configuration(ConfigurationToken=token)
             except self.client.exceptions.BadRequestException as exc:
-                if exc.response['Error']['Message'] != 'Request too early':
+                if exc.response['Error']['Message'] != 'Request too early':  # pragma: no cover
                     raise
                 logger.debug('Request too early; retrying in %d seconds', interval / 2)
                 await asyncio.sleep(interval / 2)
@@ -272,8 +275,9 @@ class AppConfigBackend(Backend):
     def _async_doctests(self) -> None:
         """Define `async` `doctest` tests in this method to improve documentation.
 
-        >>> backend = AppConfigBackend(appconfigdata_client, 'app-id', 'conf-id', 'env-id')
-        >>> content = asyncio.run(anext(backend.poll()))
+        Verify that an empty response to the `boto3` client is handled and the polling continues:
+        >>> backend = AppConfigBackend(appconfigdata_client_first_empty, 'app-id', 'conf-id', 'env-id')
+        >>> content = asyncio.run(anext(backend.poll(interval=0.01)))
         >>> print(content)
         key_0: value_0
         key_1: 1

--- a/src/config_ninja/contrib/local.py
+++ b/src/config_ninja/contrib/local.py
@@ -48,7 +48,7 @@ class LocalBackend(Backend):
     path: Path
     """Read the configuration from this file"""
 
-    def __init__(self, path: str) -> None:
+    def __init__(self, path: str | Path) -> None:
         """Set attributes to initialize the backend.
 
         If the given `path` doesn't exist, emit a warning and continue.
@@ -56,6 +56,7 @@ class LocalBackend(Backend):
         >>> with pytest.warns(RuntimeWarning):
         ...     backend = LocalBackend('does_not_exist')
         """
+        logger.debug("Initialize: %s('%s')", self.__class__.__name__, path)
         self.path = Path(path)
         if not self.path.is_file():
             warnings.warn(f'could not read file: {path}', category=RuntimeWarning, stacklevel=2)
@@ -66,6 +67,7 @@ class LocalBackend(Backend):
 
     def get(self) -> str:
         """Read the contents of the configuration file as a string."""
+        logger.debug("Read file: '%s'", self.path)
         return self.path.read_text(encoding='utf-8')
 
     async def poll(self, interval: int = 0) -> AsyncIterator[str]:
@@ -76,7 +78,7 @@ class LocalBackend(Backend):
         """
         yield self.get()
         async for _ in awatch(self.path):
-            logger.info("detected change to '%s'", self.path)
+            logger.info("Detected change to '%s'", self.path)
             yield self.get()
 
 

--- a/src/config_ninja/contrib/local.py
+++ b/src/config_ninja/contrib/local.py
@@ -60,6 +60,10 @@ class LocalBackend(Backend):
         if not self.path.is_file():
             warnings.warn(f'could not read file: {path}', category=RuntimeWarning, stacklevel=2)
 
+    def __str__(self) -> str:
+        """Return the source file's path as the string representation of the backend."""
+        return f'{self.path}'
+
     def get(self) -> str:
         """Read the contents of the configuration file as a string."""
         return self.path.read_text(encoding='utf-8')

--- a/src/config_ninja/controller.py
+++ b/src/config_ninja/controller.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-import contextlib
 import dataclasses
 import logging
 import typing
 from pathlib import Path
-from typing import TypeAlias
 
 import jinja2
 import pyspry
@@ -17,7 +15,14 @@ from config_ninja.backend import DUMPERS, Backend, FormatT, dumps, loads
 from config_ninja.contrib import get_backend
 
 if typing.TYPE_CHECKING:  # pragma: no cover
+    from typing import TypeAlias
+
     import sh
+
+    try:
+        from typing import TypeAlias
+    except ImportError:
+        from typing_extensions import TypeAlias
 
     SYSTEMD_AVAILABLE = True
 else:
@@ -34,7 +39,7 @@ __all__ = ['BackendController', 'DestSpec', 'ErrorHandler']
 logger = logging.getLogger(__name__)
 
 ActionType: TypeAlias = typing.Callable[[str], typing.Any]
-ErrorHandler: TypeAlias = typing.Callable[[dict[typing.Any, typing.Any]], contextlib.AbstractContextManager[None]]
+ErrorHandler: TypeAlias = typing.Callable[[typing.Dict[typing.Any, typing.Any]], typing.ContextManager[None]]
 
 
 @dataclasses.dataclass
@@ -101,14 +106,7 @@ class BackendController:
     """
 
     def __init__(self, settings: pyspry.Settings, key: str, handle_key_errors: ErrorHandler) -> None:
-        """Parse the settings to initialize the backend.
-
-        .. note::
-            The `settings` parameter is required and cannot be `None` (`typer.Exit(1)` is raised if
-            it is). This odd handling is due to the statement in `config_ninja.cli.main` that sets
-            `ctx.obj['settings'] = None`, which is needed to allow the `self` commands to function
-                without a settings file.
-        """
+        """Parse the settings to initialize the backend."""
         self.settings, self.key = settings, key
 
         self.handle_key_errors = handle_key_errors

--- a/src/config_ninja/controller.py
+++ b/src/config_ninja/controller.py
@@ -15,14 +15,12 @@ from config_ninja.backend import DUMPERS, Backend, FormatT, dumps, loads
 from config_ninja.contrib import get_backend
 
 if typing.TYPE_CHECKING:  # pragma: no cover
-    from typing import TypeAlias
-
     import sh
 
     try:
-        from typing import TypeAlias
+        from typing import TypeAlias  # type: ignore[attr-defined,unused-ignore]
     except ImportError:
-        from typing_extensions import TypeAlias
+        from typing_extensions import TypeAlias  # type: ignore[assignment,attr-defined,unused-ignore]
 
     SYSTEMD_AVAILABLE = True
 else:

--- a/src/config_ninja/controller.py
+++ b/src/config_ninja/controller.py
@@ -1,0 +1,191 @@
+"""Define a controller class for operating on a backend class, formatter, and output destination."""
+
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import logging
+import typing
+from pathlib import Path
+from typing import TypeAlias
+
+import jinja2
+import pyspry
+
+from config_ninja import systemd
+from config_ninja.backend import DUMPERS, Backend, FormatT, dumps, loads
+from config_ninja.contrib import get_backend
+
+if typing.TYPE_CHECKING:  # pragma: no cover
+    import sh
+
+    SYSTEMD_AVAILABLE = True
+else:
+    try:
+        import sh
+    except ImportError:  # pragma: no cover
+        sh = None
+        SYSTEMD_AVAILABLE = False
+    else:
+        SYSTEMD_AVAILABLE = hasattr(sh, 'systemctl')
+
+__all__ = ['BackendController', 'DestSpec', 'ErrorHandler']
+
+logger = logging.getLogger(__name__)
+
+ActionType: TypeAlias = typing.Callable[[str], typing.Any]
+ErrorHandler: TypeAlias = typing.Callable[[dict[typing.Any, typing.Any]], contextlib.AbstractContextManager[None]]
+
+
+@dataclasses.dataclass
+class DestSpec:
+    """Container for the destination spec parsed from `config-ninja`_'s own configuration file.
+
+    .. _config-ninja: https://bryant-finney.github.io/config-ninja/config_ninja.html
+    """
+
+    path: Path
+    """Write the configuration file to this path."""
+
+    format: FormatT | jinja2.Template
+    """Specify the format of the configuration file to write.
+
+    This property is either a `config_ninja.backend.FormatT` or a `jinja2.environment.Template`:
+    - if `config_ninja.backend.FormatT`, the identified `config_ninja.backend.DUMPERS` will be used
+        to serialize the configuration object
+    - if `jinja2.environment.Template`, this template will be used to render the configuration file
+    """
+
+    def __str__(self) -> str:
+        """Represent the destination spec as a string."""
+        if self.is_template:
+            assert isinstance(self.format, jinja2.Template)  # noqa: S101  # 👈 for static analysis
+            fmt = f'(template: {self.format.name})'
+        else:
+            fmt = f'(format: {self.format})'
+
+        return f'{fmt} -> {self.path}'
+
+    @property
+    def is_template(self) -> bool:
+        """Whether the destination uses a Jinja2 template."""
+        return isinstance(self.format, jinja2.Template)
+
+
+class BackendController:
+    """Define logic for initializing a backend from settings and interacting with it."""
+
+    backend: Backend
+    """The backend instance to use for retrieving configuration data."""
+
+    dest: DestSpec
+    """Parameters for writing the configuration file."""
+
+    handle_key_errors: ErrorHandler
+    """Context manager for handling key errors."""
+
+    key: str
+    """The key of the backend in the settings file"""
+
+    settings: pyspry.Settings
+    """`config-ninja`_'s own configuration settings
+
+    .. _config-ninja: https://bryant-finney.github.io/config-ninja/config_ninja.html
+    """
+
+    src_format: FormatT
+    """The format of the configuration object in the backend.
+
+    The named `config_ninja.backend.LOADERS` function will be used to deserialize the configuration
+    object from the backend.
+    """
+
+    def __init__(self, settings: pyspry.Settings, key: str, handle_key_errors: ErrorHandler) -> None:
+        """Parse the settings to initialize the backend.
+
+        .. note::
+            The `settings` parameter is required and cannot be `None` (`typer.Exit(1)` is raised if
+            it is). This odd handling is due to the statement in `config_ninja.cli.main` that sets
+            `ctx.obj['settings'] = None`, which is needed to allow the `self` commands to function
+                without a settings file.
+        """
+        self.settings, self.key = settings, key
+
+        self.handle_key_errors = handle_key_errors
+        self.src_format, self.backend = self._init_backend()
+        self.dest = self._get_dest()
+
+    def __str__(self) -> str:
+        """Represent the controller as its backend populating its destination."""
+        return f'{self.backend} ({self.src_format}) -> {self.dest}'
+
+    def _get_dest(self) -> DestSpec:
+        """Read the destination spec from the settings file."""
+        objects = self.settings.OBJECTS
+        with self.handle_key_errors(objects):
+            dest = objects[self.key]['dest']
+            path = Path(dest['path'])
+            if dest['format'] in DUMPERS:
+                fmt: FormatT = dest['format']  # type: ignore[assignment,unused-ignore]
+                return DestSpec(format=fmt, path=path)
+
+            template_path = Path(dest['format'])
+
+        loader = jinja2.FileSystemLoader(template_path.parent)
+        env = jinja2.Environment(autoescape=jinja2.select_autoescape(default=True), loader=loader)
+
+        return DestSpec(path=path, format=env.get_template(template_path.name))
+
+    def _init_backend(self) -> tuple[FormatT, Backend]:
+        """Get the backend for the specified configuration object."""
+        objects = self.settings.OBJECTS
+
+        with self.handle_key_errors(objects):
+            source = objects[self.key]['source']
+            backend_class: type[Backend] = get_backend(source['backend'])
+            fmt = source.get('format', 'raw')
+            if source.get('new'):
+                backend = backend_class.new(**source['new']['kwargs'])
+            else:
+                backend = backend_class(**source['init']['kwargs'])
+
+        return fmt, backend
+
+    def _do(self, action: ActionType, data: dict[str, typing.Any]) -> None:
+        if self.dest.is_template:
+            assert isinstance(self.dest.format, jinja2.Template)  # noqa: S101  # 👈 for static analysis
+            action(self.dest.format.render(data))
+        else:
+            fmt: FormatT = self.dest.format  # type: ignore[assignment]
+            action(dumps(fmt, data))
+
+    def get(self, do_print: typing.Callable[[str], typing.Any]) -> None:
+        """Retrieve and print the value of the configuration object."""
+        data = loads(self.src_format, self.backend.get())
+        self._do(do_print, data)
+
+    async def aget(self, do_print: typing.Callable[[str], typing.Any]) -> None:
+        """Poll to retrieve the latest configuration object, and print on each update."""
+        if SYSTEMD_AVAILABLE:  # pragma: no cover
+            systemd.notify()
+
+        async for content in self.backend.poll():
+            data = loads(self.src_format, content)
+            self._do(do_print, data)
+
+    def write(self) -> None:
+        """Retrieve the latest value of the configuration object, and write to file."""
+        data = loads(self.src_format, self.backend.get())
+        self._do(self.dest.path.write_text, data)
+
+    async def awrite(self) -> None:
+        """Poll to retrieve the latest configuration object, and write to file on each update."""
+        if SYSTEMD_AVAILABLE:  # pragma: no cover
+            systemd.notify()
+
+        async for content in self.backend.poll():
+            data = loads(self.src_format, content)
+            self._do(self.dest.path.write_text, data)
+
+
+logger.debug('successfully imported %s', __name__)

--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -111,7 +111,7 @@ class Service:
     Environment=PYTHONUNBUFFERED=true
     Environment=TESTING=true
     ExecStartPre=config-ninja self print
-    ExecStart=config-ninja monitor
+    ExecStart=config-ninja apply --poll
     Restart=always
     RestartSec=30s
     Type=notify

--- a/src/config_ninja/systemd.py
+++ b/src/config_ninja/systemd.py
@@ -55,7 +55,6 @@ else:
     except ImportError:  # pragma: no cover
         sh = None
 
-# pylint: disable=no-member
 SERVICE_NAME = 'config-ninja.service'
 SYSTEM_INSTALL_PATH = Path('/etc/systemd/system')
 """The file path for system-wide installation."""

--- a/src/config_ninja/templates/systemd.service.j2
+++ b/src/config_ninja/templates/systemd.service.j2
@@ -10,7 +10,7 @@ Environment={{ key }}={{ value }}
 {% endfor -%}
 {% endif -%}
 ExecStartPre={{ config_ninja_cmd }} self print
-ExecStart={{ config_ninja_cmd }} monitor
+ExecStart={{ config_ninja_cmd }} apply --poll
 Restart=always
 RestartSec=30s
 Type=notify

--- a/src/pyspry.pyi
+++ b/src/pyspry.pyi
@@ -45,6 +45,7 @@ class SourceType(TypedDict):
     """
 
 PathStr: TypeAlias = str
+"""A string representing a file path."""
 
 class DestType(TypedDict):
     """The parameters `output` and `template` are mutually exclusive."""

--- a/src/sh.pyi
+++ b/src/sh.pyi
@@ -73,6 +73,9 @@ class SystemCtl:
 contrib = Contrib()
 systemctl = SystemCtl()
 
+def config_ninja(*args: str, _tty_size: tuple[int, int] = ...) -> str:
+    """Run the `config-ninja` command."""
+
 def mkdir(*args: str) -> str:
     """Make directories."""
 

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -26,7 +26,11 @@ except ImportError:
 
 
 CONFIG_OBJECTS = ['example-local', 'example-local-template']
-GLOBAL_OPTION_ANNOTATIONS = {'verbose': cli.VerbosityAnnotation, 'version': cli.VersionAnnotation}
+GLOBAL_OPTION_ANNOTATIONS = {
+    'config': cli.SettingsAnnotation,
+    'verbose': cli.VerbosityAnnotation,
+    'version': cli.VersionAnnotation,
+}
 
 
 def _recurse_sub_apps(app: typer.Typer | None) -> list[typer.Typer]:

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -24,7 +24,7 @@ CONFIG_OBJECTS = ['example-local', 'example-local-template']
 @pytest.fixture
 def settings() -> pyspry.Settings:
     """Return a dictionary with settings for the test."""
-    return config_ninja.load_settings(Path('config-ninja-settings.yaml'))
+    return config_ninja.load_settings(Path('config-ninja-settings.yaml'))  # type: ignore[no-any-return,unused-ignore]
 
 
 @pytest.mark.parametrize('key', CONFIG_OBJECTS)

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -14,7 +14,7 @@ except ImportError:
 
 config_ninja = functools.partial(
     sh.config_ninja,
-    _tty_size=(20, 1000),  # prevent the tty width from influencing the number of lines in the output
+    _tty_size=(20, 10000),  # prevent the tty width from influencing the number of lines in the output
 )
 
 

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -67,13 +67,13 @@ def config_ninja(*args: str) -> click.testing.Result:
 @pytest.fixture
 def settings() -> pyspry.Settings:
     """Return a dictionary with settings for the test."""
-    return cn.load_settings(Path('config-ninja-settings.yaml'))  # type: ignore[no-any-return,unused-ignore]
+    return cn.load_settings(Path('config-ninja-settings.yaml'))
 
 
 @pytest.fixture
 def mock_rich_print(mocker: pytest_mock.MockFixture) -> MagicMock:
     """Patch the `rich.print` function."""
-    return mocker.patch('rich.print')  # type: ignore[no-any-return]
+    return mocker.patch('rich.print')
 
 
 @pytest.mark.parametrize(('config_key', 'command'), tuple(itertools.product(CONFIG_OBJECTS, ['get', 'apply'])))

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -2,45 +2,73 @@
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import click.testing
 import pyspry
 import pytest
+import pytest_mock
+from typer import testing
 
-import config_ninja
+import config_ninja as cn
+from config_ninja import cli, controller
 
 try:
-    import sh
+    from typing import TypedDict
 except ImportError:
-    pytest.skip('the tests in this module require `sh`', allow_module_level=True)
+    from typing_extensions import TypedDict
 
 # pylint: disable=redefined-outer-name
 
 
 CONFIG_OBJECTS = ['example-local', 'example-local-template']
 
+runner = testing.CliRunner()
+
+
+class TruthT(TypedDict):
+    """Type annotation for the structure of the truth dictionary."""
+
+    dest: controller.DestSpec
+    source: pyspry.SourceType
+    source_path: str
+
+
+def config_ninja(*args: str) -> click.testing.Result:
+    """Run the `config-ninja` command with the given arguments."""
+    return runner.invoke(cli.app, args, prog_name='config-ninja')
+
 
 @pytest.fixture
 def settings() -> pyspry.Settings:
     """Return a dictionary with settings for the test."""
-    return config_ninja.load_settings(Path('config-ninja-settings.yaml'))  # type: ignore[no-any-return,unused-ignore]
+    return cn.load_settings(Path('config-ninja-settings.yaml'))  # type: ignore[no-any-return,unused-ignore]
 
 
-@pytest.mark.parametrize('key', CONFIG_OBJECTS)
-def test_output_message_per_config(settings: pyspry.Settings, key: str) -> None:
+@pytest.fixture
+def mock_rich_print(mocker: pytest_mock.MockFixture) -> MagicMock:
+    """Patch the `rich.print` function."""
+    return mocker.patch('rich.print')  # type: ignore[no-any-return]
+
+
+@pytest.mark.parametrize('config_key', CONFIG_OBJECTS)
+def test_output_message_per_config(settings: pyspry.Settings, mock_rich_print: MagicMock, config_key: str) -> None:
     """Verify that `config-ninja apply` prints a single message for each applied controller."""
     # Arrange
-    dest = settings.OBJECTS[key]['dest']
-    source = settings.OBJECTS[key]['source']
-    src_path = source['init' if 'init' in source else 'new']['kwargs']['path']
+    truth: TruthT = {
+        'dest': controller.DestSpec.from_primitives(settings.OBJECTS[config_key]['dest']),
+        'source': (source := settings.OBJECTS[config_key]['source']),
+        'source_path': source['init' if 'init' in source else 'new']['kwargs']['path'],
+    }
 
     # Act
-    out = sh.config_ninja('apply', *CONFIG_OBJECTS)
-    no_colors = re.sub(r'\x1b\[[01359][35]?m', '', out)
+    out = config_ninja('apply', *CONFIG_OBJECTS)
 
     # Assert
-    assert f'Apply {key}' in no_colors, no_colors
-    assert dest['path'] in no_colors, no_colors
-    assert source['format'] in no_colors, no_colors
-    assert src_path in no_colors, no_colors
+    assert 0 == out.exit_code, out.stdout
+    assert len(CONFIG_OBJECTS) == mock_rich_print.call_count, mock_rich_print.call_args_list
+    mock_rich_print.assert_any_call(
+        f'Apply [yellow]{config_key}[/yellow]: '
+        f'{truth["source_path"]} ({truth["source"]["format"]}) -> {truth["dest"]}'
+    )

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -1,0 +1,30 @@
+"""Define acceptance tests for better logging (#619)."""
+
+from __future__ import annotations
+
+import functools
+
+import pytest
+
+try:
+    import sh
+except ImportError:
+    pytest.skip('the tests in this module require `sh`', allow_module_level=True)
+
+
+config_ninja = functools.partial(
+    sh.config_ninja,
+    _tty_size=(20, 1000),  # prevent the tty width from influencing the number of lines in the output
+)
+
+
+def test_output_message_per_config() -> None:
+    """Verify that `config-ninja apply` prints a single message for each applied controller."""
+    # Arrange
+    config_objects = ['example-local', 'example-local-template']
+
+    # Act
+    out = config_ninja('apply', *config_objects)
+
+    # Assert
+    assert len(config_objects) == len(out.strip().split('\n')), out.strip()

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -2,29 +2,45 @@
 
 from __future__ import annotations
 
-import functools
+import re
+from pathlib import Path
 
+import pyspry
 import pytest
+
+import config_ninja
 
 try:
     import sh
 except ImportError:
     pytest.skip('the tests in this module require `sh`', allow_module_level=True)
 
-
-config_ninja = functools.partial(
-    sh.config_ninja,
-    _tty_size=(20, 10000),  # prevent the tty width from influencing the number of lines in the output
-)
+# pylint: disable=redefined-outer-name
 
 
-def test_output_message_per_config() -> None:
+CONFIG_OBJECTS = ['example-local', 'example-local-template']
+
+
+@pytest.fixture
+def settings() -> pyspry.Settings:
+    """Return a dictionary with settings for the test."""
+    return config_ninja.load_settings(Path('config-ninja-settings.yaml'))
+
+
+@pytest.mark.parametrize('key', CONFIG_OBJECTS)
+def test_output_message_per_config(settings: pyspry.Settings, key: str) -> None:
     """Verify that `config-ninja apply` prints a single message for each applied controller."""
     # Arrange
-    config_objects = ['example-local', 'example-local-template']
+    dest = settings.OBJECTS[key]['dest']
+    source = settings.OBJECTS[key]['source']
+    path = source['init' if 'init' in source else 'new']['kwargs']['path']
 
     # Act
-    out = config_ninja('apply', *config_objects)
+    out = sh.config_ninja('apply', *CONFIG_OBJECTS)
+    no_colors = re.sub(r'\x1b\[[01359][35]?m', '', out)
 
     # Assert
-    assert len(config_objects) == len(out.strip().split('\n')), out.strip()
+    assert f'Apply {key}' in no_colors, no_colors
+    assert dest['path'] in no_colors, no_colors
+    assert source['format'] in no_colors, no_colors
+    assert path in no_colors, no_colors

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -27,7 +27,8 @@ except ImportError:
 
 CONFIG_OBJECTS = ['example-local', 'example-local-template']
 GLOBAL_OPTION_ANNOTATIONS = {
-    'config': cli.SettingsAnnotation,
+    'config': cli.ConfigAnnotation,
+    'get_help': cli.HelpAnnotation,
     'verbose': cli.VerbosityAnnotation,
     'version': cli.VersionAnnotation,
 }

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -33,7 +33,7 @@ def test_output_message_per_config(settings: pyspry.Settings, key: str) -> None:
     # Arrange
     dest = settings.OBJECTS[key]['dest']
     source = settings.OBJECTS[key]['source']
-    path = source['init' if 'init' in source else 'new']['kwargs']['path']
+    src_path = source['init' if 'init' in source else 'new']['kwargs']['path']
 
     # Act
     out = sh.config_ninja('apply', *CONFIG_OBJECTS)
@@ -43,4 +43,4 @@ def test_output_message_per_config(settings: pyspry.Settings, key: str) -> None:
     assert f'Apply {key}' in no_colors, no_colors
     assert dest['path'] in no_colors, no_colors
     assert source['format'] in no_colors, no_colors
-    assert path in no_colors, no_colors
+    assert src_path in no_colors, no_colors

--- a/tests/acceptance/test_619.py
+++ b/tests/acceptance/test_619.py
@@ -93,6 +93,7 @@ def test_output_message_per_config(settings: pyspry.Settings, mock_rich_print: M
     )
 
 
+@pytest.mark.usefixtures('monkeypatch_systemd')
 @pytest.mark.parametrize(
     'command',
     [
@@ -117,7 +118,7 @@ def test_verbosity_argument(command: list[str], caplog: pytest.LogCaptureFixture
 
     # Assert
     assert 0 == out.exit_code, out.stdout
-    assert (cli.LOG_VERBOSITY_MESSAGE % 'DEBUG') in caplog.messages, caplog.text
+    assert cli.LOG_VERBOSITY_MESSAGE % 'DEBUG' in caplog.messages, caplog.text
 
 
 @pytest.mark.parametrize('cmd_func_arg', itertools.product(typer_cmd_infos, GLOBAL_OPTION_ANNOTATIONS))

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,6 +9,7 @@ from typing import Any, Iterator, TypeVar
 from unittest import mock
 
 import pytest
+import pytest_mock
 from boto3 import Session
 from botocore.exceptions import ClientError
 from botocore.paginate import PageIterator, Paginator
@@ -255,3 +256,9 @@ example_file.__doc__ = f"""Write the test configuration to a file in the tempora
 {MOCK_YAML_CONFIG.decode('utf-8')}
 ```
 """
+
+
+@pytest.fixture(autouse=True)
+def mock_logging_basic_config(mocker: pytest_mock.MockerFixture) -> mock.MagicMock:
+    """Mock the `logging.basicConfig` function."""
+    return mocker.patch('logging.basicConfig')  # type: ignore[no-any-return]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -165,10 +165,51 @@ def mock_latest_config() -> GetLatestConfigurationResponseTypeDef:
 
 
 @pytest.fixture
+def mock_latest_config_first_empty() -> GetLatestConfigurationResponseTypeDef:
+    """Mock the response from `get_latest_configuration`.
+
+    Return an empty `bytes` on the first iteration, and `MOCK_YAML_CONFIG` on the second. This supports testing
+        `config_ninja.contrib.appconfig.AppConfig`'s response to an empty return value.
+    """
+    was_called: list[bool] = []
+
+    def mock_read(*_: Any, **__: Any) -> bytes:
+        if was_called:
+            return MOCK_YAML_CONFIG
+        was_called.append(True)
+        return b''
+
+    mock_config_stream = mock.MagicMock(spec_set=StreamingBody)
+    mock_config_stream.read = mock_read
+    return {
+        'NextPollConfigurationToken': 'token',
+        'NextPollIntervalInSeconds': 0,
+        'ContentType': 'application/json',
+        'Configuration': mock_config_stream,
+        'VersionLabel': 'v1',
+        'ResponseMetadata': {
+            'RequestId': '',
+            'HostId': '',
+            'HTTPStatusCode': 200,
+            'HTTPHeaders': {},
+            'RetryAttempts': 3,
+        },
+    }
+
+
+@pytest.fixture
 def mock_appconfigdata_client(mock_latest_config: mock.MagicMock) -> AppConfigDataClient:
     """Mock the low-level `boto3` client for the `AppConfigData` service."""
     mock_client = mock.MagicMock(name='mock_appconfigdata_client', spec_set=AppConfigDataClient)
     mock_client.get_latest_configuration.return_value = mock_latest_config
+    return mock_client
+
+
+@pytest.fixture
+def mock_appconfigdata_client_first_empty(mock_latest_config_first_empty: mock.MagicMock) -> AppConfigDataClient:
+    """Mock the low-level `boto3` client for the `AppConfigData` service."""
+    mock_client = mock.MagicMock(name='mock_appconfigdata_client', spec_set=AppConfigDataClient)
+    mock_client.get_latest_configuration.return_value = mock_latest_config_first_empty
     return mock_client
 
 
@@ -261,4 +302,4 @@ example_file.__doc__ = f"""Write the test configuration to a file in the tempora
 @pytest.fixture(autouse=True)
 def mock_logging_basic_config(mocker: pytest_mock.MockerFixture) -> mock.MagicMock:
     """Mock the `logging.basicConfig` function."""
-    return mocker.patch('logging.basicConfig')  # type: ignore[no-any-return]
+    return mocker.patch('logging.basicConfig')

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -69,15 +69,15 @@ def test_help(args: Sequence[str]) -> None:
     """Verify the `-h` argument matches `--help` and the default command."""
     results = runner.invoke(app, args)
     stdout = clean(results.stdout)
-    assert results.exit_code == 0
+    assert 0 == results.exit_code
     assert stdout.startswith('Usage')
 
 
 def test_version() -> None:
     """Verify the `version` command returns the correct version."""
     result = runner.invoke(app, ['version'])
-    assert result.exit_code == 0
-    assert result.stdout.strip() == config_ninja.__version__
+    assert 0 == result.exit_code
+    assert config_ninja.__version__ == result.stdout.strip()
 
 
 def test_missing_settings(mocker: MockerFixture) -> None:
@@ -89,7 +89,7 @@ def test_missing_settings(mocker: MockerFixture) -> None:
     result = runner.invoke(app, ['self', 'print'])
 
     # Assert
-    assert result.exit_code == 0
+    assert 0 == result.exit_code
     assert all(text in result.stdout for text in ['WARNING', 'Could not find', 'config-ninja', 'settings file'])
 
 
@@ -97,7 +97,7 @@ def test_missing_settings(mocker: MockerFixture) -> None:
 def test_get_example_appconfig() -> None:
     """Get the 'example-appconfig' configuration (as specified in config-ninja-settings.yaml)."""
     result = runner.invoke(app, ['get', 'example-appconfig'])
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     # note: logging on windows dislikes how the runner captures output and prints a traceback, so
     # ... :      just make sure that the YAML config is included _in_ the output
     assert MOCK_YAML_CONFIG.decode('utf-8') in result.stdout.strip()
@@ -106,8 +106,8 @@ def test_get_example_appconfig() -> None:
 def test_get_example_local(settings: dict[str, Any]) -> None:
     """Get the 'example-local' configuration (as specified in config-ninja-settings.yaml)."""
     result = runner.invoke(app, ['get', 'example-local'])
-    assert result.exit_code == 0, result.exception
-    assert result.stdout.replace('\n', '').strip() == json.dumps(settings)
+    assert 0 == result.exit_code, result.exception
+    assert json.dumps(settings) == result.stdout.replace('\n', '').strip()
 
 
 @pytest.mark.usefixtures('_patch_awatch')
@@ -115,15 +115,15 @@ def test_get_example_local(settings: dict[str, Any]) -> None:
 def test_get_example_local_poll(mocker: MockerFixture, settings: dict[str, Any]) -> None:
     """Test the `poll` command with a local file."""
     # Arrange
-    mock_print = mocker.patch('config_ninja.cli.print')
+    mock_print = mocker.patch('rich.print')
     expected_call_count = 2  # 1 for the initial print, 2 for the patched awatch()
 
     # Act
     result = runner.invoke(app, ['get', '--poll', 'example-local'])
 
     # Assert
-    assert result.exit_code == 0, result.exception
-    assert mock_print.call_count == expected_call_count
+    assert 0 == result.exit_code, result.exception
+    assert expected_call_count == mock_print.call_count
     assert (
         mock_print.call_args_list[0][0][0].strip() == mock_print.call_args_list[1][0][0].strip() == json.dumps(settings)
     )
@@ -133,7 +133,7 @@ def test_self_print() -> None:
     """Test the `self print` command."""
     result = runner.invoke(app, ['self', 'print'])
 
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert 'example-local' in result.stdout.strip()
     assert 'example-appconfig' in result.stdout.strip()
 
@@ -143,8 +143,8 @@ def test_apply_example_local(settings: dict[str, Any]) -> None:
     result = runner.invoke(app, ['apply', 'example-local'])
     output = Path(settings['CONFIG_NINJA_OBJECTS']['example-local']['dest']['path']).read_text(encoding='utf-8').strip()
 
-    assert result.exit_code == 0, result.exception
-    assert output == json.dumps(settings)
+    assert 0 == result.exit_code, result.exception
+    assert json.dumps(settings) == output
 
 
 def test_apply_example_local_template(settings: dict[str, Any]) -> None:
@@ -156,10 +156,9 @@ def test_apply_example_local_template(settings: dict[str, Any]) -> None:
         .strip()
     )
 
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert (
-        output
-        == tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
+        tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
             {
                 'CONFIG_NINJA_OBJECTS': {
                     'example-local-template': {
@@ -168,6 +167,7 @@ def test_apply_example_local_template(settings: dict[str, Any]) -> None:
                 }
             }
         ).strip()
+        == output
     )
 
 
@@ -177,10 +177,11 @@ def test_apply_example_local_poll(settings: dict[str, Any]) -> None:
     """Test the `apply --poll` command with a local file backend."""
     result = runner.invoke(app, ['apply', '--poll', 'example-local'])
 
-    assert result.exit_code == 0, result.exception
-    assert Path(settings['CONFIG_NINJA_OBJECTS']['example-local']['dest']['path']).read_text(
-        encoding='utf-8'
-    ).strip() == json.dumps(settings)
+    assert 0 == result.exit_code, result.exception
+    assert (
+        json.dumps(settings)
+        == Path(settings['CONFIG_NINJA_OBJECTS']['example-local']['dest']['path']).read_text(encoding='utf-8').strip()
+    )
 
 
 @pytest.mark.usefixtures('_patch_awatch')
@@ -194,10 +195,9 @@ def test_apply_example_local_template_poll(settings: dict[str, Any]) -> None:
         .strip()
     )
 
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert (
-        output
-        == tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
+        tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
             {
                 'CONFIG_NINJA_OBJECTS': {
                     'example-local-template': {
@@ -206,6 +206,7 @@ def test_apply_example_local_template_poll(settings: dict[str, Any]) -> None:
                 }
             }
         ).strip()
+        == output
     )
 
 
@@ -220,11 +221,10 @@ def test_apply_all(settings: dict[str, Any]) -> None:
     outputs = [p.read_text().strip() for p in paths]
 
     # Assert
-    assert result.exit_code == 0, result.exception
-    assert outputs[0] == json.dumps(settings)
+    assert 0 == result.exit_code, result.exception
+    assert json.dumps(settings) == outputs[0]
     assert (
-        outputs[1]
-        == tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
+        tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
             {
                 'CONFIG_NINJA_OBJECTS': {
                     'example-local-template': {
@@ -233,14 +233,8 @@ def test_apply_all(settings: dict[str, Any]) -> None:
                 }
             }
         ).strip()
+        == outputs[1]
     )
-
-
-@pytest.mark.usefixtures('settings')
-def test_apply_all_poll() -> None:
-    """Ensure the `--poll` argument cannot be used without a key."""
-    result = runner.invoke(app, ['--config', 'examples/local-backend.yaml', 'apply', '--poll'])
-    assert result.exit_code != 0
 
 
 @pytest.mark.usefixtures('_patch_awatch')
@@ -256,11 +250,10 @@ def test_monitor_local(settings: dict[str, Any]) -> None:
     outputs = [p.read_text().strip() for p in paths]
 
     # Assert
-    assert result.exit_code == 0, result.exception
-    assert outputs[0] == json.dumps(settings)
+    assert 0 == result.exit_code, result.exception
+    assert json.dumps(settings) == outputs[0]
     assert (
-        outputs[1]
-        == tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
+        tomlkit.dumps(  # pyright: ignore[reportUnknownMemberType]
             {
                 'CONFIG_NINJA_OBJECTS': {
                     'example-local-template': {
@@ -269,6 +262,7 @@ def test_monitor_local(settings: dict[str, Any]) -> None:
                 }
             }
         ).strip()
+        == outputs[1]
     )
 
 
@@ -281,7 +275,7 @@ def test_install_no_systemd(monkeypatch: pytest.MonkeyPatch) -> None:
     result = runner.invoke(app, ['self', 'install'])
 
     # Assert
-    assert result.exit_code != 0
+    assert 0 != result.exit_code
     assert result.stdout.startswith('ERROR: Missing systemd!')
 
 
@@ -290,7 +284,7 @@ def test_install() -> None:
     """Verify the `install` command works as expected."""
     result = runner.invoke(app, ['self', 'install'])
 
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert result.stdout.startswith('Installing')
     assert 'SUCCESS' in result.stdout
 
@@ -334,7 +328,7 @@ def test_install_env(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     # Assert
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     for name, value in variables.items():
         assert f'Environment={name}={value}' in result.stdout
 
@@ -344,7 +338,7 @@ def test_install_print_only() -> None:
     """Verify the `install` command respects the `--print-only` argument."""
     result = runner.invoke(app, ['self', 'install', '--print-only'])
 
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert _clean_output(str(systemd.SYSTEM_INSTALL_PATH)) in _clean_output(result.stdout)
 
 
@@ -363,7 +357,7 @@ def test_install_called_with_sudo(mocker: MockerFixture) -> None:
     result = runner.invoke(app, ['self', 'install'])
 
     # Assert
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     sudo.__enter__.assert_not_called()
 
 
@@ -380,7 +374,7 @@ def test_install_run_as(run_as: str) -> None:
     result = runner.invoke(app, ['self', 'install', '--print-only', '--run-as', run_as])
 
     # Assert
-    assert result.exit_code == 0, {result.exception: str(result.stdout)}
+    assert 0 == result.exit_code, {result.exception: str(result.stdout)}
     assert f'User={user}' in result.stdout
     if group:
         assert f'Group={group}' in result.stdout
@@ -398,7 +392,7 @@ def test_install_variables() -> None:
     result = runner.invoke(app, ['self', 'install', '--print-only', *args])
 
     # Assert
-    assert result.exit_code == 0, {result.exception: str(result.stdout)}
+    assert 0 == result.exit_code, {result.exception: str(result.stdout)}
     for line in expected:
         assert line in result.stdout
 
@@ -411,7 +405,7 @@ def test_install_variables_invalid() -> None:
     result = runner.invoke(app, ['self', 'install', '--print-only', '--var', pair])
 
     # Assert
-    assert result.exit_code == 1
+    assert 1 == result.exit_code
     assert f'Invalid argument (expected VARIABLE=VALUE pair): {pair}' in result.stdout
 
 
@@ -427,7 +421,7 @@ def test_uninstall() -> None:
     result = runner.invoke(app, ['self', 'uninstall', '--user'])
 
     # Assert
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert result.stdout.startswith('Uninstalling')
     assert 'SUCCESS' in result.stdout
 
@@ -444,7 +438,7 @@ def test_uninstall_print_only() -> None:
     result = runner.invoke(app, ['self', 'uninstall', '--print-only'])
 
     # Assert
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     assert _clean_output(str(systemd.SYSTEM_INSTALL_PATH)) in _clean_output(result.stdout)
     assert content in result.stdout
 
@@ -464,5 +458,5 @@ def test_uninstall_called_with_sudo(mocker: MockerFixture) -> None:
     result = runner.invoke(app, ['self', 'uninstall'])
 
     # Assert
-    assert result.exit_code == 0, result.exception
+    assert 0 == result.exit_code, result.exception
     sudo.__enter__.assert_not_called()

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -89,7 +89,7 @@ def test_missing_settings(mocker: MockerFixture) -> None:
     result = runner.invoke(app, ['self', 'print'])
 
     # Assert
-    assert 0 == result.exit_code
+    assert 1 == result.exit_code
     assert all(text in result.stdout for text in ['WARNING', 'Could not find', 'config-ninja', 'settings file'])
 
 

--- a/tests/test_config_ninja/test_cli.py
+++ b/tests/test_config_ninja/test_cli.py
@@ -80,7 +80,7 @@ def test_version() -> None:
     assert config_ninja.__version__ == result.stdout.strip()
 
 
-def test_missing_settings(mocker: MockerFixture) -> None:
+def test_missing_settings(mocker: MockerFixture, caplog: pytest.LogCaptureFixture) -> None:
     """Verify errors are handled correctly when the settings file is missing."""
     # Arrange
     mocker.patch('config_ninja.DEFAULT_SETTINGS_PATHS', new=[Path('does not'), Path('exist')])
@@ -90,7 +90,7 @@ def test_missing_settings(mocker: MockerFixture) -> None:
 
     # Assert
     assert 1 == result.exit_code
-    assert all(text in result.stdout for text in ['WARNING', 'Could not find', 'config-ninja', 'settings file'])
+    assert cli.LOG_MISSING_SETTINGS_MESSAGE in caplog.text
 
 
 @pytest.mark.usefixtures('mock_full_session')

--- a/tests/test_config_ninja/test_main.py
+++ b/tests/test_config_ninja/test_main.py
@@ -11,11 +11,9 @@ def test_main(mocker: MockerFixture) -> None:
     """Ensure the `typer` app is called."""
     # Arrange
     mock_app = mocker.patch.object(__main__, 'app')
-    mock_basic_config = mocker.patch('logging.basicConfig')
 
     # Act
     __main__.main()
 
     # Assert
     mock_app.assert_called_once()
-    mock_basic_config.assert_called_once()

--- a/tools/install.py
+++ b/tools/install.py
@@ -611,7 +611,7 @@ def _do_uninstall(installer: Installer) -> None:
         else:  # pragma: no cover  # windows
             uninstall = input(prompt)
 
-        if not uninstall.lower().startswith('y'):
+        if not uninstall.lower().startswith('y'):  # pragma: no cover
             sys.stderr.write(f'{failure}: Aborted uninstallation ❌\n')
             sys.exit(RC_PATH_EXISTS)
 


### PR DESCRIPTION
Closes #619

Additionally:
- support multiple `KEY` arguments for the `get`, `apply` commands 
- depreciate the `monitor` command (`apply --poll` ought to be used instead)